### PR TITLE
Fix for no body returned when accept header contains empty header value

### DIFF
--- a/src/Csg.AspNetCore.ExceptionManagement/Handlers.cs
+++ b/src/Csg.AspNetCore.ExceptionManagement/Handlers.cs
@@ -27,7 +27,8 @@ namespace Csg.AspNetCore.ExceptionManagement
 
             httpContext.Response.StatusCode = context.Result.StatusCode;
 
-            if (requestHeaders.Accept == null || requestHeaders.Accept?.Any(x => JsonMediaType.IsSubsetOf(x)) == true)
+            // If no accept header is sent, assume we want JSON I guess.
+            if (requestHeaders.Accept == null || requestHeaders.Accept.Count == 0 || requestHeaders.Accept?.Any(x => JsonMediaType.IsSubsetOf(x)) == true)
             {
                 httpContext.Response.ContentType = "application/json; chartset=utf8";
 
@@ -53,6 +54,10 @@ namespace Csg.AspNetCore.ExceptionManagement
                 httpContext.Response.ContentType = "text/plain";
 
                 await httpContext.Response.WriteAsync($"Error: {context.Result.ErrorTitle}\nDetail: {context.Result.ErrorDetail}");
+            }
+            else
+            {
+                //Should we write something here? Should
             }
         }
     }


### PR DESCRIPTION
Fix for an issue Rebecca found after upgrading to .NET Core 3.1, where the middleware does not return a JSON body (or any body at all) if the request headers collection has an empty Accept header value instead of a null Accept header value.